### PR TITLE
Allow users of the client to pass in a cached access token

### DIFF
--- a/lib/athena_health/client.rb
+++ b/lib/athena_health/client.rb
@@ -1,7 +1,12 @@
 module AthenaHealth
   class Client
-    def initialize(version:, key:, secret:)
-      @api = AthenaHealth::Connection.new(version: version, key: key, secret: secret)
+    def initialize(version:, key:, secret:, token: nil)
+      @api = AthenaHealth::Connection.new(
+        version: version,
+        key: key,
+        secret: secret,
+        token: token,
+      )
     end
 
     include Endpoints::Practices

--- a/lib/athena_health/connection.rb
+++ b/lib/athena_health/connection.rb
@@ -5,10 +5,11 @@ module AthenaHealth
     BASE_URL    = 'https://api.athenahealth.com'.freeze
     AUTH_PATH   = { 'v1' => 'oauth', 'preview1' => 'oauthpreview', 'openpreview1' => 'oauthopenpreview' }
 
-    def initialize(version:, key:, secret:)
+    def initialize(version:, key:, secret:, token: nil)
       @version = version
       @key = key
       @secret = secret
+      @token = token
     end
 
     def authenticate

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -2,7 +2,8 @@ def client_attributes
   {
     version: 'preview1',
     key: 'test_key',
-    secret: 'test_secret'
+    secret: 'test_secret',
+    token: nil
   }
 end
 


### PR DESCRIPTION
Use Case:

I work at Smart Scheduling (an MDP Partner recently acquired by athena) and we need to sync a large portion of athena's data in real time.  If we weren't able to cache the access token and refresh it ourselves we would hit the 100k token/a day limit.  We spawn a lot of workers which then will be instantiating new instances of the `AthenaHealth::Client`.  We'd also like the perf benefit of not having to do an OAuth handshake for ever new instance of the client. 

This seemed like a simple approach to optionally allow an access token if users of the client are willing to manage the authorization/refreshing themselves (which we are).  If you'd like a more advanced implementation please let me know and I'd be happy to put more time into the gem!

