### PR TITLE
Adds providerlist to departments

### DIFF
--- a/lib/athena_health/department.rb
+++ b/lib/athena_health/department.rb
@@ -26,5 +26,6 @@ module AthenaHealth
     attribute :ecommercecreditcardtypes,     Array
     attribute :zip,                          String
     attribute :communicatorbrandid,          Integer
+    attribute :providerlist,                 Array
   end
 end


### PR DESCRIPTION
When you pass in the `providerlist: true` flag to all departments it returns an array of provider id's associated to that department.  We use this for syncing purposes to make a DepartmentProvider join table.