### PR TITLE
Adds 'show' endpoint for appointment type

### DIFF
--- a/lib/athena_health/endpoints/appointments.rb
+++ b/lib/athena_health/endpoints/appointments.rb
@@ -11,6 +11,16 @@ module AthenaHealth
         AppointmentTypeCollection.new(response)
       end
 
+      def find_appointment_type(practice_id:, appointment_type_id:, params: {})
+        response = @api.call(
+          endpoint: "#{practice_id}/appointmenttypes/#{appointment_type_id}",
+          method: :get,
+          params: params
+        )
+
+        AppointmentType.new(response.first)
+      end
+
       def open_appointment_slots(practice_id:, department_id:, provider_id:, params: {})
         response = @api.call(
           endpoint: "#{practice_id}/appointments/open",

--- a/spec/fixtures/vcr_cassettes/appointment_type.yml
+++ b/spec/fixtures/vcr_cassettes/appointment_type.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.athenahealth.com/oauthpreview/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 22 Feb 2016 07:59:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Mashery Proxy
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1d-110.mashery.com
+      transfer-encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"test_access_token","token_type":"bearer","expires_in":3600,"refresh_token":"test_refresh_token"}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.athenahealth.com/oauthpreview/token
+  recorded_at: Mon, 22 Feb 2016 07:59:58 GMT
+- request:
+    method: get
+    uri: https://api.athenahealth.com/preview1/195944/appointmenttypes/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Authorization:
+      - Bearer test_access_token
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Cneonction:
+      - close
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 May 2016 17:59:19 GMT
+      Expires:
+      - Mon, 06 Jan 1975 16:00:00 GMT
+      Pragma:
+      - No-cache
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      X-Mashery-Message-ID:
+      - 01c075b8-d6ef-4620-9140-86fa5cb0610a
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1b-127.mashery.com
+      Content-Length:
+      - '179'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"shortname":"OV","name":"Office Visit","duration":"10","patientdisplayname":"Office
+        Visit","appointmenttypeid":"2","generic":"true","patient":"true","templatetypeonly":"false"}]'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.athenahealth.com/preview1/195944/appointmenttypes/2
+  recorded_at: Fri, 13 May 2016 17:59:19 GMT
+recorded_with: VCR 3.0.1

--- a/spec/lib/endpoints/appointments_spec.rb
+++ b/spec/lib/endpoints/appointments_spec.rb
@@ -98,4 +98,20 @@ describe AthenaHealth::Endpoints::Appointments do
       end
     end
   end
+
+  describe '#find_appointment_type' do
+    let(:attributes) do
+      {
+        practice_id: 195944,
+        appointment_type_id: 2
+      }
+    end
+
+    it 'returns instance of AppointmentType' do
+      VCR.use_cassette('appointment_type') do
+        expect(client.find_appointment_type(attributes))
+          .to be_an_instance_of AthenaHealth::AppointmentType
+      end
+    end
+  end
 end


### PR DESCRIPTION
Was a little confused how to properly do VCR testing with this setup.  I ended up creating a new valid access_token, then replacing `token: nil` in [here](https://github.com/zywy/athena_health/blob/master/spec/support/client.rb#L6).  Made the API request successfully and recorded it.  Then copied and pasted the authentication handshake from another cassette [like this one](https://github.com/zywy/athena_health/blob/master/spec/fixtures/vcr_cassettes/all_patients.yml#L3-L39).  Finally I went into the cassette and deleted my valid token and replaced with the `test_access_token`.  

It seems somewhat hacky to me... maybe you guys set this up differently?

Another potential solution if you're open to it...

Use something like [dotenv](https://github.com/bkeepers/dotenv) and have a `.env.example` with all the environment variables people need to run the test suite.  Replace the `support/client.rb` file with something like this:

```
def client_attributes
  {
    version: ENV['ATHENA_API_VERSION'],
    key: ENV['ATHENA_API_KEY'],
    secret: ENV['ATHENA_API_SECRET'],
    token: nil
  }
end
```

Then API requests should just work fine as long as people set up their own credentials.  Finally, you can filter out the credentials from the cassettes doing [something along these lines.](https://github.com/vcr/vcr/issues/201)

Lemme know what you think!