### PR TITLE
Adds appointments changed/subscription endpoints

### DIFF
--- a/lib/athena_health/endpoints/appointments.rb
+++ b/lib/athena_health/endpoints/appointments.rb
@@ -174,6 +174,14 @@ module AthenaHealth
 
         InsuranceCollection.new(response)
       end
+
+      def create_appointment_subscription(practice_id:, params: {})
+        @api.call(
+          endpoint: "#{practice_id}/appointments/changed/subscription",
+          method: :post,
+          params: params
+        )
+      end
     end
   end
 end

--- a/lib/athena_health/endpoints/appointments.rb
+++ b/lib/athena_health/endpoints/appointments.rb
@@ -182,6 +182,18 @@ module AthenaHealth
           params: params
         )
       end
+
+      def changed_appointments(practice_id:, department_id:, params: {})
+        response = @api.call(
+          endpoint: "#{practice_id}/appointments/changed",
+          method: :get,
+          params: params.merge!(
+            departmentid: department_id
+          )
+        )
+
+        AppointmentCollection.new(response)
+      end
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/appointment_subscription.yml
+++ b/spec/fixtures/vcr_cassettes/appointment_subscription.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.athenahealth.com/oauthpreview/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 16 Feb 2016 12:43:23 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Mashery Proxy
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1b-106.mashery.com
+      transfer-encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"test_access_token","token_type":"bearer","expires_in":3600,"refresh_token":"test_refresh_token"}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.athenahealth.com/oauthpreview/token
+  recorded_at: Tue, 16 Feb 2016 12:43:24 GMT
+- request:
+    method: post
+    uri: https://api.athenahealth.com/preview1/195900/appointments/changed/subscription
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Authorization:
+      - Bearer test_access_token
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jul 2016 16:38:06 GMT
+      Expires:
+      - Mon, 06 Jan 1975 16:00:00 GMT
+      nnCoection:
+      - close
+      Pragma:
+      - No-cache
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      X-Mashery-Message-ID:
+      - 9a7e7c5a-7508-4516-a78f-8bfa20fd745e
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1d-107.mashery.com
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":"true"}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.athenahealth.com/preview1/195900/appointments/changed/subscription
+  recorded_at: Thu, 21 Jul 2016 16:38:06 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/appointments_changed.yml
+++ b/spec/fixtures/vcr_cassettes/appointments_changed.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.athenahealth.com/oauthpreview/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 16 Feb 2016 12:43:23 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Mashery Proxy
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1b-106.mashery.com
+      transfer-encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"test_access_token","token_type":"bearer","expires_in":3600,"refresh_token":"test_refresh_token"}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.athenahealth.com/oauthpreview/token
+  recorded_at: Tue, 16 Feb 2016 12:43:24 GMT
+- request:
+    method: get
+    uri: https://api.athenahealth.com/preview1/195900/appointments/changed?departmentid=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Authorization:
+      - Bearer test_access_token
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 Jul 2016 16:50:17 GMT
+      Expires:
+      - Mon, 06 Jan 1975 16:00:00 GMT
+      nnCoection:
+      - close
+      Pragma:
+      - No-cache
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      X-Mashery-Message-ID:
+      - 92cc0eb8-709e-4c31-bb2b-a9277865e566
+      X-Mashery-Responder:
+      - prod-j-worker-us-east-1e-105.mashery.com
+      Content-Length:
+      - '34'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"totalcount":0,"appointments":[]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.athenahealth.com/preview1/195900/appointments/changed?departmentid=1
+  recorded_at: Thu, 21 Jul 2016 16:50:17 GMT
+recorded_with: VCR 3.0.1

--- a/spec/lib/endpoints/appointments_spec.rb
+++ b/spec/lib/endpoints/appointments_spec.rb
@@ -308,4 +308,15 @@ describe AthenaHealth::Endpoints::Appointments do
       end
     end
   end
+
+  describe '#changed_appointments' do
+    it "returns instance of AppointmentCollection" do
+      VCR.use_cassette('appointments_changed') do
+        expect(client.changed_appointments(
+          practice_id: 195900,
+          department_id: 1,
+        )).to be_an_instance_of AthenaHealth::AppointmentCollection
+      end
+    end
+  end
 end

--- a/spec/lib/endpoints/appointments_spec.rb
+++ b/spec/lib/endpoints/appointments_spec.rb
@@ -298,4 +298,14 @@ describe AthenaHealth::Endpoints::Appointments do
       end
     end
   end
+
+  describe '#create_appointment_subscription' do
+    it "returns success => true" do
+      VCR.use_cassette('appointment_subscription') do
+        expect(client.create_appointment_subscription(
+          practice_id: 195_900
+        )).to eq 'success' => 'true'
+      end
+    end
+  end
 end


### PR DESCRIPTION
In order to prevent syncing past appointments you can create a subscription for a practice and then just fetch the new appointments.  This pull requests adds the appropriate endpoints.

The #changed_appointments method could potentially use more logic/protection to confirm that the user making the call actually has a subscription.  If you think we need that I or you can add that functionality in a separate PR?